### PR TITLE
Change prop name from onClusterClick to onClick in example

### DIFF
--- a/.storybook/examples/event-listeners.js
+++ b/.storybook/examples/event-listeners.js
@@ -22,7 +22,7 @@ const EventListeners = () => (
     />
 
     <MarkerClusterGroup
-      onClusterClick={cluster =>
+      onClick={cluster =>
         logAction('cluster-click', cluster, cluster.layer.getAllChildMarkers())
       }
     >


### PR DESCRIPTION
`cluster` is automatically added to the event name [here](https://github.com/yuzhva/react-leaflet-markercluster/blob/master/src/react-leaflet-markercluster.js#L23)