### PR TITLE
Update react-leaflet-markercluster.js

### DIFF
--- a/src/react-leaflet-markercluster.js
+++ b/src/react-leaflet-markercluster.js
@@ -1,34 +1,32 @@
-import { createPathComponent } from '@react-leaflet/core';
-import L from 'leaflet';
+import L from 'leaflet'
+import { createPathComponent } from '@react-leaflet/core'
+import 'leaflet.markercluster'
 
-require('leaflet.markercluster');
+function createMarkerCluster({ children: _c, ...props }, context) {
+  const clusterProps = {}
+  const clusterEvents = {}
+  // Splitting props and events to different objects
+  Object.entries(props).forEach(([propName, prop]) =>
+    propName.startsWith('on')
+      ? (clusterEvents[propName] = prop)
+      : (clusterProps[propName] = prop)
+  )
+  const instance = new L.MarkerClusterGroup(clusterProps)
 
-const MarkerClusterGroup = createPathComponent(
-  ({ children: _c, ...props }, ctx) => {
-    const clusterProps = {};
-    const clusterEvents = {};
-
-    // Splitting props and events to different objects
-    Object.entries(props).forEach(([propName, prop]) =>
-      propName.startsWith('on')
-        ? (clusterEvents[propName] = prop)
-        : (clusterProps[propName] = prop)
-    );
-
-    // Creating markerClusterGroup Leaflet element
-    const markerClusterGroup = new L.markerClusterGroup(clusterProps);
-
-    // Initializing event listeners
-    Object.entries(clusterEvents).forEach(([eventAsProp, callback]) => {
-      const clusterEvent = `cluster${eventAsProp.substring(2).toLowerCase()}`;
-      markerClusterGroup.on(clusterEvent, callback);
-    });
-
-    return {
-      instance: markerClusterGroup,
-      context: { ...ctx, layerContainer: markerClusterGroup },
-    };
+  // Initializing event listeners
+  Object.entries(clusterEvents).forEach(([eventAsProp, callback]) => {
+    const clusterEvent = `cluster${eventAsProp.substring(2).toLowerCase()}`
+    instance.on(clusterEvent, callback)
+  })
+  return {
+    instance,
+    context: {
+      ...context,
+      layerContainer: instance,
+    },
   }
-);
+}
 
-export default MarkerClusterGroup;
+const MarkerCluster = createPathComponent(createMarkerCluster)
+
+export default MarkerCluster


### PR DESCRIPTION
As documented here (https://github.com/PaulLeCam/react-leaflet/issues/897#issuecomment-1121179538) several people me included had difficulties making react-leaflet-markercluster work with newer versions of the ecosystem. I finally got it to work with above code and following system settings.

    docker-compose on Debian
    "next": "^12.1.5",
    "react-dom": "^18.1.0",
    "react": "^18.1.0",
    "leaflet": "^1.8.0",
    "leaflet-defaulticon-compatibility": "^0.1.1",
    "leaflet.markercluster": "^1.5.3",
    "@react-leaflet/core": "^2.0.0",
    "@types/leaflet": "^1.7.9",
    "react-leaflet": "^4.0.0",